### PR TITLE
Add link to new location of API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # NovoServe Public API Documentation
-Documentation for NovoServe's public API.
+This repository contains code examples for NovoServe's Public API.
+
+The API documentation is hosted on our API server.
+- [API documentation](https://api.novoserve.com/docs)
+- [Raw OpenAPI specification](https://api.novoserve.com/v0/swagger.json)
 
 ## Code examples
 Code examples to use our API are located in the `examples/` directory.  


### PR DESCRIPTION
Since the documentation is now also publicly accessible, it seems like a good idea to add a link to it here to make it easier to find.